### PR TITLE
Issue "SyntaxError: Missing Parentheses..."

### DIFF
--- a/src/SConscript
+++ b/src/SConscript
@@ -1,6 +1,6 @@
 Import('env')
 
-print '[I] building cpu-stat (' + env['mode'] + ')'
+print ('[I] building cpu-stat (' + env['mode'] + ')')
 
 # sources
 sources = env.Glob ('*.cpp');


### PR DESCRIPTION
```
scons: Reading SConscript files ...
  File "/home/userdir/cpu-stat-master/src/SConscript", line 3

    print '[I] building cpu-stat (' + env['mode'] + ')'

    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

SyntaxError: Missing parentheses in call to 'print'. Did you mean print(...)?
```